### PR TITLE
Return tree base path and files found.

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,9 +13,13 @@ function tree(inputTree, filter) {
     var paths = walkSync(inputTree.directory);
  
     if (filter) {
-      return filter(paths, inputTree);
+      paths = filter(paths, inputTree);
     }
-    return paths;
+
+    return {
+      files: paths,
+      directory: inputTree.directory
+    }
   });
 }
  


### PR DESCRIPTION
In order to confirm that the contents of a trees output are correct you must be able to `fs.readFileSync(path.join(baseDir, itemPath))`. Without this change, we only have the relative path for each output file so we can confirm that files exist in the correct location, but not assert that their content is correct.
