### PR TITLE
Adding prepSubject to allow for stubbing

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ function tree(plugin, fixturePath, filter) {
  * @param  {Object} options
  * @property {Function} options.subject The function that is under test
  * @property {String} options.fixturePath The path to the fixtures being used for the test
+ * @property {Function} [options.prepSubject] Lifecycle method called before the testing to allow you to setup spies on the test subject. You are passed the instance of the subject.
  * @property {Function} [options.filter] Filtering function that is applied to result of the build.
  * @return {Promise}
  */


### PR DESCRIPTION
This allows you to do a prep step on your plugin prior to the test subject executing. This allows you to setup any mocks or spies on the test subject.
