### PR TITLE
bump walk-sync, add entries to returned results

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,10 @@ function tree(plugin, fixturePath, filter) {
   var build = function() {
     process.chdir(fixturePath);
     return builder.build().then(function(tree) {
-      var paths = walkSync(tree.directory);
+      var entries = walkSync.entries(tree.directory);
+      paths = entries.map(function(entry) {
+        return entry.relativePath;
+      });
 
       if (filter) {
         paths = filter(paths, tree);
@@ -21,6 +24,7 @@ function tree(plugin, fixturePath, filter) {
 
       return {
         files: paths,
+        entries: entries,
         directory: tree.directory,
         builder: function() {
           return build().then(function(results) {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   "dependencies": {
     "broccoli": "^0.16.2",
     "rsvp": "^3.0.17",
-    "walk-sync": "^0.1.3"
+    "walk-sync": "^0.2.6"
   }
 }


### PR DESCRIPTION
having entries would be nice in tests so we can use `entry.isDirectory` and or `entry.fullpath`. Keep paths/files as entry.relativePath as before for back compat.

This request bumps walk-sync all the way up to 0.2.6 but anything over 0.2.2 would work.
https://github.com/joliss/node-walk-sync/blob/master/CHANGELOG.md

Tested against broccoli-babel-transpiler broccoli-filter broccoli-persistent-filter broccoli-stew by running their test whist npm link'ed  to my local.
